### PR TITLE
feat[OrderExecutor]: Resolve #2 - `OrderExecuter.create_orders` should always return `orders`

### DIFF
--- a/order_executor.py
+++ b/order_executor.py
@@ -427,6 +427,8 @@ class OrderExecutor():
                                           best_price_limit=best_price_limit,
                                           extra_bid_pct=extra_bid_pct)
 
+        return orders
+
     def update_order_price(self):
         """更新委託單，將委託單的限價調整成當天最後一筆價格。
         （讓沒成交的限價單去追價）"""


### PR DESCRIPTION
See https://github.com/finlab-python/order_executor/issues/2 for more details.

Resolves: #2