### PR TITLE
feat(order_executor): add buy_only and sell_only parameters to order …

### DIFF
--- a/order_executor.py
+++ b/order_executor.py
@@ -623,6 +623,8 @@ class OrderExecutor():
             raise ValueError("Only one of 'market_order', 'best_price_limit', or 'extra_bid_pct' can be set.")
         if extra_bid_pct < -0.1 or extra_bid_pct > 0.1:
             raise ValueError("The extra_bid_pct parameter is out of the valid range 0 to 0.1")
+        if buy_only and sell_only:
+            raise ValueError("The buy_only and sell_only parameters cannot be set to True at the same time.")
 
         if cancel_orders:
             self.cancel_orders()


### PR DESCRIPTION
# Overview
This commit adds buy-only and sell-only control parameters to the order execution functionality, allowing users to selectively execute only buy or sell orders during position synchronization. This enhancement provides more flexible control over trading operations.

# Key Features
- Buy-only mode: Execute only buy orders while skipping sell orders
- Sell-only mode: Execute only sell orders while skipping buy orders 
- Maintains existing order execution logic with added control parameters

# Changes Made
- Added `buy_only` and `sell_only` boolean parameters to `execute_orders()` method
- Added `buy_only` and `sell_only` boolean parameters to `create_orders()` method
- Added order filtering logic based on the new control parameters
- Updated method documentation to reflect new parameters

# Testing
N/A

# Impact
This feature gives users more granular control over order execution:
- Can execute only buy orders when accumulating positions
- Can execute only sell orders when reducing positions
- Maintains backward compatibility with existing code

# Example Usage

```python
from finlab.online.order_executor import OrderExecutor

# Create order executor
executor = OrderExecutor(target_position, account)

# Execute only buy orders
executor.create_orders(buy_only=True)

# Execute only sell orders  
executor.create_orders(sell_only=True)

# Execute both buy and sell orders (default behavior)
executor.create_orders()
```