### PR TITLE
fix(order_executor): pass buy_only and sell_only parameters to execute_orders method

### DIFF
--- a/order_executor.py
+++ b/order_executor.py
@@ -745,7 +745,7 @@ class OrderExecutor():
         """
         self.cancel_orders()
         orders = self.generate_orders(progress, progress_precision)
-        return self.execute_orders(orders, market_order, best_price_limit, view_only, extra_bid_pct, cancel_orders=False, buy_only=False, sell_only=False)
+        return self.execute_orders(orders, market_order, best_price_limit, view_only, extra_bid_pct, cancel_orders=False, buy_only=buy_only, sell_only=sell_only)
     
     
     def update_order_price(self, extra_bid_pct=0):


### PR DESCRIPTION
# Overview
This PR fixes a parameter propagation bug in the `OrderExecutor` class where `buy_only` and `sell_only` control parameters were not correctly passed through the execution chain, preventing users from filtering orders by direction.

# Key Features
- Fixed parameter passing for buy/sell filtering
- Maintains consistent order control behavior
- Preserves backward compatibility

# Changes Made
```python
def create_orders(self, market_order=False, best_price_limit=False, view_only=False, 
                 extra_bid_pct=0, progress=1, progress_precision=0, buy_only=False, sell_only=False):
    self.cancel_orders()
    orders = self.generate_orders(progress, progress_precision)
    # Before:
    # return self.execute_orders(orders, market_order, best_price_limit, view_only, extra_bid_pct, 
    #                          cancel_orders=False, buy_only=False, sell_only=False)
    
    # After: Correctly propagate buy_only and sell_only parameters
    return self.execute_orders(orders, market_order, best_price_limit, view_only, extra_bid_pct,
                             cancel_orders=False, buy_only=buy_only, sell_only=sell_only)
```

# Impact
- Buy/sell filtering now works as documented
- No changes to existing functionality when parameters are not used
- Fixes issue where users could not selectively execute orders by direction

# Documentation
No documentation changes needed as the functionality was already documented but not working properly.