### PR TITLE
fix(quote_to_stock): update close price to use lastPrice

### DIFF
--- a/schwab_account.py
+++ b/schwab_account.py
@@ -525,7 +525,7 @@ def quote_to_stock(json_response: Dict[str, Any]) -> Stock:
         open=quote['openPrice'],
         high=quote['highPrice'],
         low=quote['lowPrice'],
-        close=quote['closePrice'],
+        close=quote['lastPrice'],
         bid_price=quote['bidPrice'],
         ask_price=quote['askPrice'],
         bid_volume=quote['bidSize'],


### PR DESCRIPTION
# Overview
This commit fixes a bug in the `quote_to_stock` function to ensure the `close` field correctly reflects the **last traded price** (`lastPrice`) instead of the incorrect `closePrice`. This change ensures that the stock data accurately represents the most recent trade information, which is critical for real-time trading decisions.

# Key Features
- Corrected the `close` field in the `quote_to_stock` function to use `quote['lastPrice']`.

# Changes Made
- Updated the `quote_to_stock` function:
  - Changed `close=quote['closePrice']` to `close=quote['lastPrice']`.

# Impact
This bug fix ensures that the `Stock` object created by the `quote_to_stock` function contains accurate data for the `close` field:
- Provides the correct **last traded price**, which is essential for accurate market analysis and trading decisions.
- Improves data integrity for downstream processes relying on the `Stock` object.