### PR TITLE
Avoid applying future next_weights after stop events

### DIFF
--- a/core/position.py
+++ b/core/position.py
@@ -18,6 +18,19 @@ from finlab.online.core.utils import greedy_allocation
 logger = logging.getLogger(__name__)
 
 
+def _market_close_at_timestamp(market: Any, timestamp: Any) -> datetime.datetime | None:
+    if timestamp is None:
+        return None
+
+    if timestamp in ("weight", "next_weight"):
+        return None
+
+    try:
+        return market.market_close_at_timestamp(timestamp)
+    except Exception:
+        return None
+
+
 def _make_entry(
     sid: str,
     quantity: float | Decimal,
@@ -500,7 +513,12 @@ class Position:
 
         now = datetime.datetime.now(tz=datetime.timezone.utc)
 
-        if now >= next_trading_time:
+        next_weights_time = _market_close_at_timestamp(
+            report.market, getattr(report.next_weights, "name", None)
+        )
+        use_next_weights_time = next_weights_time or next_trading_time
+
+        if now >= use_next_weights_time:
             w = report.next_weights.copy()
         else:
             w = report.weights.copy()

--- a/tests/unit/test_position_utilities.py
+++ b/tests/unit/test_position_utilities.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import datetime
+import sys
+import types
 from decimal import Decimal
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
+import pandas as pd
 from finlab.online.enums import OrderCondition
 from finlab.online.order_executor import Position
 
@@ -149,3 +155,51 @@ def test_position_from_weight() -> None:
         raise AssertionError
     except Exception:
         assert True
+
+
+class _ReportMarket:
+    def market_close_at_timestamp(self, timestamp):
+        if isinstance(timestamp, pd.Timestamp):
+            timestamp = timestamp.to_pydatetime()
+        if timestamp.tzinfo is None:
+            return timestamp.replace(tzinfo=datetime.timezone.utc)
+        return timestamp.astimezone(datetime.timezone.utc)
+
+    def get_board_lot_size(self):
+        return 1000
+
+
+def test_position_from_report_does_not_use_future_next_weights_after_stop_event() -> None:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    weights = pd.Series([1.0], index=["2330"], name=now - datetime.timedelta(days=30))
+    next_weights = pd.Series(
+        [1.0], index=["1101"], name=now + datetime.timedelta(days=7)
+    )
+    report = SimpleNamespace(
+        weights=weights,
+        next_weights=next_weights,
+        actions=pd.Series(["sl"], index=["2330"], dtype=object),
+        next_trading_date=now - datetime.timedelta(days=1),
+        market=_ReportMarket(),
+    )
+
+    cloud_report_module = types.ModuleType("finlab.portfolio.cloud_report")
+    cloud_report_module.CloudReport = type("CloudReport", (), {})
+    portfolio_module = types.ModuleType("finlab.portfolio")
+    portfolio_module.cloud_report = cloud_report_module
+
+    with patch.dict(
+        sys.modules,
+        {
+            "finlab.portfolio": portfolio_module,
+            "finlab.portfolio.cloud_report": cloud_report_module,
+        },
+    ):
+        position = Position.from_report(
+            report,
+            fund=1_000_000,
+            price={"2330": 100, "1101": 50},
+            odd_lot=True,
+        )
+
+    assert position.position == []

--- a/tests/unit/test_position_utilities.py
+++ b/tests/unit/test_position_utilities.py
@@ -203,3 +203,49 @@ def test_position_from_report_does_not_use_future_next_weights_after_stop_event(
         )
 
     assert position.position == []
+
+
+def test_position_from_report_keeps_current_weights_not_stopped() -> None:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    weights = pd.Series(
+        [0.25, 0.25, 0.25, 0.25],
+        index=["9905 大華", "2897 王道銀行", "2916 滿心", "8433 弘帆"],
+        name=now - datetime.timedelta(days=30),
+    )
+    next_weights = pd.Series(
+        [0.25, 0.25, 0.25, 0.25],
+        index=["1342", "2248", "2432", "2637"],
+        name=now + datetime.timedelta(days=7),
+    )
+    report = SimpleNamespace(
+        weights=weights,
+        next_weights=next_weights,
+        actions=pd.Series(
+            ["sl_", "sl_", "sl"],
+            index=["4442 竣邦-KY", "2851 中再保", "2916 滿心"],
+            dtype=object,
+        ),
+        next_trading_date=now - datetime.timedelta(days=1),
+        market=_ReportMarket(),
+    )
+
+    cloud_report_module = types.ModuleType("finlab.portfolio.cloud_report")
+    cloud_report_module.CloudReport = type("CloudReport", (), {})
+    portfolio_module = types.ModuleType("finlab.portfolio")
+    portfolio_module.cloud_report = cloud_report_module
+
+    with patch.dict(
+        sys.modules,
+        {
+            "finlab.portfolio": portfolio_module,
+            "finlab.portfolio.cloud_report": cloud_report_module,
+        },
+    ):
+        position = Position.from_report(
+            report,
+            fund=1_000_000,
+            price={"9905": 21.3, "2897": 10.15, "2916": 46.0, "8433": 57.5},
+            odd_lot=True,
+        )
+
+    assert {p["stock_id"] for p in position.position} == {"9905", "2897", "8433"}


### PR DESCRIPTION
## Summary

- Use `next_weights.name` as the switch time when it is available, instead of always switching at `next_trading_date`.
- Prevent stop-loss / take-profit event dates from causing `Position.from_report()` to apply a later rebalance's full `next_weights` early.
- Add a unit regression that mirrors the Discord report: stop event date already passed, but `next_weights.name` is still in the future.

## Context

Discord user Cyrus (@cyrus3156, ID: 844079905335148544) reported `PortfolioSyncManager` producing `report4` positions from `next_weights` even though the next full rebalance was later. Debug output showed:

```text
weights.name: 2026-03-31
next_weights.name: 2026-04-30
next_trading_date: 2026-04-22
now: 2026-04-23
```

The 2026-04-22 date appears to be a stop event date, while the full next rebalance weights are dated 2026-04-30.

Related issue: finlab-python/finlab#75

## Test

```bash
PYTHONPATH=/tmp/finlab-src python -m pytest finlab/online/tests/unit/test_position_utilities.py -q
```

Result: `4 passed in 0.09s`