### PR TITLE
fix(sinopac): fetch contracts on demand when Stocks lookup misses

### DIFF
--- a/brokers/sinopac.py
+++ b/brokers/sinopac.py
@@ -359,7 +359,16 @@ class SinopacAccount(Account, RealtimeProvider):
             pass
         stocks = getattr(getattr(self.api, "Contracts", None), "Stocks", None)
         if stocks is not None:
-            return stocks[stock_id]
+            try:
+                contract = stocks[stock_id]
+            except KeyError:
+                contract = None
+            if contract is not None:
+                return contract
+        # Contracts are not populated yet. This happens on shioaji < 1.7 where
+        # login() used fetch_contract=False and no contracts were downloaded, so
+        # the lookup above misses even for actively traded stocks. Fetch on
+        # demand and retry instead of surfacing a bare "Contract not found".
         self.api.fetch_contracts(contract_download=sj.constant.SecurityType.Stock)
         return self.api.Contracts.Stocks[stock_id]
 


### PR DESCRIPTION
## 問題
finlab 永豐 broker 在 shioaji `<1.7` 環境下，用戶下單時對正常交易的股票（例：8421 旭源）回 `下單失敗: 'Contract not found: 8421'`。

## 根因
`SinopacAccount` 登入用 `api.login(..., fetch_contract=False)`，shioaji <1.7 因此**不會下載合約檔**。`_get_contract()` 走到：
```python
stocks = getattr(getattr(self.api, 'Contracts', None), 'Stocks', None)
if stocks is not None:
    return stocks[stock_id]   # 空的 Stocks -> KeyError('Contract not found: 8421')
self.api.fetch_contracts(...)  # 因為 stocks 不是 None，永遠到不了這行
```
空的 `Contracts.Stocks` 物件 `is not None` 為真，`fetch_contracts()` fallback 永遠不會被觸發。shioaji 1.7 走 `api.contracts.get()` 不受影響。

## 修法
Stocks 查詢 miss（KeyError 或 None）時落到 `fetch_contracts()` + 重試；真正下市的代碼仍照常 raise。

## 測試
以 stub 模擬三種情境（不需真實 shioaji）驗證抽取自本檔的實際 `_get_contract`：
- shioaji <1.7：Stocks 空 → 觸發 fetch_contracts → 取得合約 ✅
- shioaji 1.7：`api.contracts.get()` 直接解析 ✅
- 真正下市代碼：fetch 後仍 miss → KeyError 照常拋出 ✅

嚴重度：中（影響所有 pin `shioaji<1.7` 且有實際下單的永豐用戶；升級 shioaji>=1.7 可繞過）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)